### PR TITLE
Drop table fix

### DIFF
--- a/src/com/database/BaseModelObject.cfc
+++ b/src/com/database/BaseModelObject.cfc
@@ -2658,7 +2658,7 @@ component accessors="true" output="false" {
 	/**
     * I drop the current table.
     **/
-	private function dropTable(){
+	private void function dropTable(){
 		variables.dao.dropTable( this.getTable() );
 	}
 

--- a/src/com/database/IDAOConnector.cfc
+++ b/src/com/database/IDAOConnector.cfc
@@ -62,7 +62,7 @@ interface {
 	tabledef function makeTable( required tabledef tabledef ) output = false
 		description ="I create a table based on the passed in tabledef object's properties.";
 
-	tabledef function dropTable( required string table ) output = false
+	void function dropTable( required string table ) output = false
 		description="I drop a table based on the passed in table name.";
 
 }

--- a/src/com/database/dao.cfc
+++ b/src/com/database/dao.cfc
@@ -1058,8 +1058,8 @@
 		/**
 		* Delegates the dropping of a "table" to the underlying persistence storage "connector"
 		**/
-		public tabledef function dropTable( required string table ){
-			return getConn().dropTable( arguments.table );
+		public void function dropTable( required string table ){
+			getConn().dropTable( arguments.table );
 		}
 
 		/**

--- a/src/com/database/mssql.cfc
+++ b/src/com/database/mssql.cfc
@@ -564,7 +564,7 @@
 		/**
 	    * I drop a table based on the passed in table name.
 	    **/
-		public tabledef function dropTable( required string table ) output = false{
+		public void function dropTable( required string table ) output = false{
 			getDao().execute( "
 				IF OBJECT_ID('#this.getTable()#', 'U') IS NOT NULL
   				DROP TABLE [#this.getTable()#]

--- a/src/com/database/mysql.cfc
+++ b/src/com/database/mysql.cfc
@@ -605,7 +605,7 @@
 		/**
 	    * I drop a table based on the passed in table name.
 	    **/
-		public tabledef function dropTable( required string table ) output = false{
+		public void function dropTable( required string table ) output = false{
 			getDao().execute( "DROP TABLE IF EXISTS `#this.getTable()#`" );
 		}
 	</cfscript>


### PR DESCRIPTION
According to the IDAOConnector interface the method `dropTable()` should return `tabledef`, but the functions in the CFCs interfacing IDAOConnector didn't return anything. So I removed `return` and the returntype from those functions and changed the definition to return void.